### PR TITLE
Update new articles page layout

### DIFF
--- a/src/Article.tsx
+++ b/src/Article.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { useEffect } from 'react';
 
 type Article = {
     id: number;
@@ -25,6 +26,10 @@ const fetchArticle = async (id: string) => {
 };
 
 export default function Article() {
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, []);
+
     const params = useParams<{id: string}>();
 
     const {data: article, isLoading, isError} = useQuery<Article, Error>(

--- a/src/ContentsArea.tsx
+++ b/src/ContentsArea.tsx
@@ -14,14 +14,17 @@ export default function ContentsArea({children}: ContentsAreaProps) {
                 flexDirection: {xs: 'column', md: 'row'},
                 px: 5,
                 pt: 5,
+                pb: 5,
                 fontSize: {xs: '1.2rem', md: '1rem'},
                 }}>
                 <Box sx={{ 
                     width: {xs: 1, md: 5/6},
                     textAlign: 'left',
                     pr: {xs: 0, md: 5},
+                    mr: {xs: 0, md: 5},
+                    backgroundColor: 'whitesmoke',
                     }}>
-                    {children}
+                        <Box sx={{p: 2}}>{children}</Box>
                 </Box>
                 <Box sx={{ 
                     width: {xs:1, md: 1/6} }}>

--- a/src/NewArticles.tsx
+++ b/src/NewArticles.tsx
@@ -3,10 +3,13 @@ import {useQuery} from 'react-query';
 import Article from './Article';
 import Box from '@mui/material/Box';
 import {Link} from 'react-router-dom';
+import ThumbnailBox from './ThumbnailBox';
 
 type Article = {
     id: number;
     title: string;
+    content: string;
+    imagePaths: string[];
 };
 
 type Articles = Article[];
@@ -33,13 +36,22 @@ export default function NewArticles() {
         return <div>エラーが発生しました</div>;
     }
     return (
-        <Box sx={{textAlign: 'left'}}>
+        <Box className="flex-col">
             {articles?.map((article) => (
-                <React.Fragment key={article.id}>
-                <Link to={`/articles/${article.id}`}>
-                    <h1>{article.title}</h1>
-                </Link>
-                </React.Fragment>
+                <Box key={article.id}
+                className=" bg-white pd-2 border border-transparent hover:border hover:border-blue-600 transition duration-2 mb-2">
+                    <Link to={`/articles/${article.id}`}>
+                        <h1 className="pt-2 text-center xs:text-xl md:text-2xl">{article.title}</h1>
+                        <div className="flex pb-4">
+                            <div className="w-2/5 px-4">
+                            <ThumbnailBox width="100%">
+                            <img src={article.imagePaths[0]} alt="thumbnail" />
+                            </ThumbnailBox>
+                            </div>
+                            <p className="line-clamp-1 w-3/5 px-4 text-lg">{article.content}</p>
+                        </div>
+                    </Link>
+                </Box>
             ))}
         </Box>
     );

--- a/src/NewArticles.tsx
+++ b/src/NewArticles.tsx
@@ -41,15 +41,11 @@ export default function NewArticles() {
                 <Box key={article.id}
                 className=" bg-white pd-2 border border-transparent hover:border hover:border-blue-600 transition duration-2 mb-2">
                     <Link to={`/articles/${article.id}`}>
-                        <h1 className="pt-2 text-center xs:text-xl md:text-2xl">{article.title}</h1>
-                        <div className="flex pb-4">
-                            <div className="w-2/5 px-4">
-                            <ThumbnailBox width="100%">
-                            <img src={article.imagePaths[0]} alt="thumbnail" />
-                            </ThumbnailBox>
-                            </div>
-                            <p className="line-clamp-1 w-3/5 px-4 text-lg">{article.content}</p>
+                        <div className="flex justify-center items-center h-[200px] overflow-hidden">
+                        <img src={article.imagePaths[0]} alt="thumbnail" className="max-h-full max-w-full object-contain"/>
                         </div>
+                        <h1 className="pt-2 px-4 text-center xs:text-xl md:text-2xl">{article.title}</h1>
+                        <p className="px-4 text-lg xs:line-clamp-3 sm:line-clamp-5 md:line-clamp-6">{article.content}</p>
                     </Link>
                 </Box>
             ))}

--- a/src/NewArticles.tsx
+++ b/src/NewArticles.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {useQuery} from 'react-query';
 import Article from './Article';
 import Box from '@mui/material/Box';
+import MuiPagination from '@mui/material/Pagination';
 import {Link} from 'react-router-dom';
-import ThumbnailBox from './ThumbnailBox';
 
 type Article = {
     id: number;
@@ -28,6 +28,18 @@ export default function NewArticles() {
         () => fetchArticleItem()
     );
 
+    // ページネーション用の変数
+    const [page, setPage] = React.useState(1);
+    const pageSize = 10;
+
+    const handlePageChange = (event: React.ChangeEvent<unknown>, value: number) => {
+        setPage(value);
+    }
+
+    const indexOfLast = page * pageSize;
+    const indexOfFirst = indexOfLast - pageSize;
+    const currentArticles = articles?.slice(indexOfFirst, indexOfLast);
+
     if (isLoading) {
         return <div>読み込み中...</div>;
     }
@@ -37,7 +49,7 @@ export default function NewArticles() {
     }
     return (
         <Box className="flex-col">
-            {articles?.map((article) => (
+            {currentArticles?.map((article) => (
                 <Box key={article.id}
                 className=" bg-white pd-2 border border-transparent hover:border hover:border-blue-600 transition duration-2 mb-2">
                     <Link to={`/articles/${article.id}`}>
@@ -49,6 +61,13 @@ export default function NewArticles() {
                     </Link>
                 </Box>
             ))}
+                <MuiPagination
+                count={Math.ceil((articles?.length || 0) / pageSize)}
+                page={page}
+                onChange={handlePageChange}
+                size='large'
+                sx={{display: 'flex', justifyContent: 'center', pt: 2, pb: 2}}
+                />
         </Box>
     );
 }

--- a/src/SidebarNewArticleItems.tsx
+++ b/src/SidebarNewArticleItems.tsx
@@ -1,6 +1,7 @@
 import {useQuery} from 'react-query';
 import Box from '@mui/material/Box';
 import React from 'react';
+import ThumbnailBox from './ThumbnailBox';
 
 type Article = {
     id: number;
@@ -39,20 +40,13 @@ export default function SidebarNewArticleItems() {
             <h3 className="text-xl">最新記事</h3>
             <ul className="xs:grid grid-cols-2 md:block">
             {articles?.slice(0, maxArticleLength).map((article) => (
-                <li key={article.id} className="border border-gray-2 xs:m-2 md:mb-2">
+                <li key={article.id} className="border border-gray-2 xs:m-2 md:mb-2 hover:border hover:border-blue-600 ">
                     <a href={`/articles/${article.id}`}
                     className="group hover:text-blue-700 cursor-pointer">
-                        <Box
-                            component="img"
-                            sx={{
-                                objectFit: 'cover',
-                                width: '100%',
-                            }}
-                            alt="thumbnail"
-                            src={article.imagePaths[0]}
-                            className="group-hover:bg-gray-200 transition duration-2"
-                        />
-                        <p className="group-hover:bg-gray-200 transition duration-2 xs:text-sm md:text-md">{article.title}</p>
+                        <ThumbnailBox width="100%">
+                            <img src={article.imagePaths[0]} alt="thumbnail" />
+                        </ThumbnailBox>
+                        <p className="xs:text-sm md:text-md">{article.title}</p>
                     </a>
                 </li>
             ))}

--- a/src/SidebarNewArticleItems.tsx
+++ b/src/SidebarNewArticleItems.tsx
@@ -1,7 +1,7 @@
 import {useQuery} from 'react-query';
 import Box from '@mui/material/Box';
 import React from 'react';
-import ThumbnailBox from './ThumbnailBox';
+import SidebarThumbnailBox from './SidebarThumbnailBox';
 
 type Article = {
     id: number;
@@ -43,9 +43,9 @@ export default function SidebarNewArticleItems() {
                 <li key={article.id} className="border border-gray-2 xs:m-2 md:mb-2 hover:border hover:border-blue-600 ">
                     <a href={`/articles/${article.id}`}
                     className="group hover:text-blue-700 cursor-pointer">
-                        <ThumbnailBox width="100%">
+                        <SidebarThumbnailBox>
                             <img src={article.imagePaths[0]} alt="thumbnail" />
-                        </ThumbnailBox>
+                        </SidebarThumbnailBox>
                         <p className="xs:text-sm md:text-md">{article.title}</p>
                     </a>
                 </li>

--- a/src/SidebarThumbnailBox.tsx
+++ b/src/SidebarThumbnailBox.tsx
@@ -1,17 +1,16 @@
 import Box from "@mui/material/Box";
 
-type ThumbnailBoxProps = {
+type SidebarThumbnailBoxProps = {
     children: React.ReactNode;
-    width: string;
 };
 
-export default function ThumbnailBox({children, width}: ThumbnailBoxProps) {
+export default function SidebarThumbnailBox({children}: SidebarThumbnailBoxProps) {
     return (
       <Box 
         sx={{ 
           position: 'relative',
-          width: {xs: width, md: width},
-          paddingTop: {xs: width, md: width},
+          width: '100%',
+          paddingTop: '100%',
           backgroundColor: 'white',
         }}
       >

--- a/src/ThumbnailBox.tsx
+++ b/src/ThumbnailBox.tsx
@@ -1,0 +1,34 @@
+import Box from "@mui/material/Box";
+
+type ThumbnailBoxProps = {
+    children: React.ReactNode;
+    width: string;
+};
+
+export default function ThumbnailBox({children, width}: ThumbnailBoxProps) {
+    return (
+      <Box 
+        sx={{ 
+          position: 'relative',
+          width: {xs: width, md: width},
+          paddingTop: {xs: width, md: width},
+          backgroundColor: 'white',
+        }}
+      >
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
+    );
+  }


### PR DESCRIPTION
新規記事ページのレイアウトを書き換えた。
・本文を途中まで表示
・サムネイル画像を表示
・ページネーションを追加

#46 を解決。